### PR TITLE
liftover is performed using 1-based coordinates against a 0-based chain file

### DIFF
--- a/harmoniser/liftover.py
+++ b/harmoniser/liftover.py
@@ -39,12 +39,12 @@ def isNumber(value):
 
 
 def map_bp_to_build_via_liftover(chromosome, bp, build_map):
-    if isNumber(bp):
-        data = build_map.convert_coordinate('chr' + str(chromosome), int(bp))
+    if is_number(bp):
+        data = build_map.convert_coordinate('chr' + str(chromosome), int(bp)-1)
         if data is not None:
             if len(data) > 0:
-                return data[0][1]
-    return None
+                return data[0][0].replace("chr",""), int(data[0][1])+1
+    return "Unable to be mapped", None
 
 
 def map_bp_to_build_via_ensembl(chromosome, bp, from_build, to_build):


### PR DESCRIPTION
Hello all!
as descrobed in the title - we believe there is a bug due to the disconnect between 1-based gneome coordinates and 0-based chain files by pyliftover (chain files from the LiftOver tool from pyliftover: https://github.com/EBISPOT/gwas-sumstats-harmoniser/blob/master/harmoniser/map_to_build.py#49)

This diagram walks through the effects of incorrectly passing the 1-based coordinates (lines 2 and 3) versus the actual genomic change between the builds (line 1) and the correct output produced by passing the 0-based coordinate (line 4):

![image](https://user-images.githubusercontent.com/32375926/197506467-81c38906-05fc-4170-981d-2ca6abce30ac.png)

Credit to @katiedelange :)