### PR TITLE
50 harmonised to master

### DIFF
--- a/bin/liftover.py
+++ b/bin/liftover.py
@@ -46,7 +46,7 @@ def map_bp_to_build_via_liftover(chromosome, bp, build_map, coordinate):
         data = build_map.convert_coordinate('chr' + str(chromosome), int(bp)-int(coordinate))
         if data is not None:
             if len(data) > 0:
-                return data[0][1]+int(1)
+                return str(data[0][1]+int(1))
     return None
 
 

--- a/bin/main_pysam.py
+++ b/bin/main_pysam.py
@@ -30,7 +30,7 @@ def main():
     code_counter = Counter()
     if args.hm_sumstats:
         out_handle = open_gzip(args.hm_sumstats, "wb")
-    out_header = SumStatsTable(sumstats_file=args.sumstats)._set_header_order()
+        out_header = SumStatsTable(sumstats_file=args.sumstats)._set_header_order()
     
     #######YUE################
     tbx=pysam.TabixFile(args.vcf)

--- a/bin/map_to_build_nf.py
+++ b/bin/map_to_build_nf.py
@@ -112,7 +112,7 @@ def main():
     argparser.add_argument('-from_build', help='The original build e.g. "36" for NCBI36 or hg18', required=True)
     argparser.add_argument('-to_build', help='The latest (desired) build e.g. "38"', required=True)
     argparser.add_argument('-chroms', help='A list of chromosomes to process', default=DEFAULT_CHROMS)
-    argparser.add_argument('-coordinate', help='index', required=True)
+    argparser.add_argument('-coordinate', help='index', nargs='?', const="1-based", required=True)
     args = argparser.parse_args()
 
     ss = args.f

--- a/modules/local/failed_copy.nf
+++ b/modules/local/failed_copy.nf
@@ -7,8 +7,8 @@ process failed_copy {
         "${task.ext.docker}${task.ext.docker_version}" }"
 
     input:
-    tuple val(GCST), path(qc_tsv), path (log), path (yaml), val(status), path(raw_yaml), path(tsv)
-
+    tuple val(GCST), path(raw_yaml), path(tsv), path(qc_tsv), path (log), path (yaml), val(status)
+    
     output:
     tuple val(GCST),val(status), env(copy), emit: done
 

--- a/modules/local/failed_copy.nf
+++ b/modules/local/failed_copy.nf
@@ -7,7 +7,7 @@ process failed_copy {
         "${task.ext.docker}${task.ext.docker_version}" }"
 
     input:
-    tuple val(GCST), path(tsv), path(qc_tsv), path (log), val(status)
+    tuple val(GCST), path(qc_tsv), path (log), path (yaml), val(status), path(raw_yaml), path(tsv)
 
     output:
     tuple val(GCST),val(status), env(copy), emit: done
@@ -26,5 +26,6 @@ process failed_copy {
     fi
 
     copy="copied"
+    rm -vr ${launchDir}/$GCST
     """
 }

--- a/modules/local/ftp_copy.nf
+++ b/modules/local/ftp_copy.nf
@@ -5,7 +5,7 @@ process ftp_copy{
    
 
     input:
-    tuple val(GCST), path(tsv), path(qc_tsv), path (log), path (yaml), val(status)
+    tuple val(GCST), path(qc_tsv), path (log), path (yaml), val(status), path(raw_yaml), path(tsv)
 
     output:
     tuple val(GCST), val(status), env(copy), emit: done
@@ -38,7 +38,6 @@ process ftp_copy{
          copy="copied"
          echo "\$md5_h_tsv  ${GCST}.h.tsv.gz" > \$path/md5sum.txt
          echo "\$md5_h_tbi  ${GCST}.h.tsv.gz.tbi" >> \$path/md5sum.txt
-         rm -v ${params.all_harm_folder}/$tsv
          rm -vr ${launchDir}/$GCST
     else
          copy="failed_copy"

--- a/modules/local/ftp_copy.nf
+++ b/modules/local/ftp_copy.nf
@@ -5,8 +5,8 @@ process ftp_copy{
    
 
     input:
-    tuple val(GCST), path(qc_tsv), path (log), path (yaml), val(status), path(raw_yaml), path(tsv)
-
+    tuple val(GCST), path(raw_yaml), path(tsv), path(qc_tsv), path (log), path (yaml), val(status)
+    
     output:
     tuple val(GCST), val(status), env(copy), emit: done
 

--- a/subworkflows/local/major_direction.nf
+++ b/subworkflows/local/major_direction.nf
@@ -40,11 +40,11 @@ workflow major_direction{
     
     ten_percent_counts(count_ch)
     // need to count the  number of outputs and wait until all the chromosomes have completed
-    int nchr=params.chrom.size()-4
+    int nchr=params.chrom.size()
     ten_to_sum=ten_percent_counts.out
                       .ten_sc
                       .groupTuple(by: 0)
-                      .branch{pass:it[1].size()>nchr}
+                      .branch{pass:it[1].size()==nchr}
                       .map{it[0]}
 
     // example: ten_to_sum [GCST1],[GCST2].....

--- a/subworkflows/local/major_direction.nf
+++ b/subworkflows/local/major_direction.nf
@@ -40,11 +40,11 @@ workflow major_direction{
     
     ten_percent_counts(count_ch)
     // need to count the  number of outputs and wait until all the chromosomes have completed
-    int nchr=params.chrom.size()
+    int nchr=params.chrom.size()-4
     ten_to_sum=ten_percent_counts.out
                       .ten_sc
                       .groupTuple(by: 0)
-                      .branch{pass:it[1].size()==nchr}
+                      .branch{pass:it[1].size()>nchr}
                       .map{it[0]}
 
     // example: ten_to_sum [GCST1],[GCST2].....

--- a/subworkflows/local/move_files.nf
+++ b/subworkflows/local/move_files.nf
@@ -7,7 +7,7 @@ workflow move_files{
     
     main:
     
-    har_result_ch=input.map{it[0,2..6]}.branch{success:it.contains("SUCCESS_HARMONIZATION")
+    har_result_ch=input.branch{success:it.contains("SUCCESS_HARMONIZATION")
     failed:it.contains("FAILED_HARMONIZATION")}
     //success_harmonized_file move to FTP
     //failed harmonized file move to Failed folder


### PR DESCRIPTION
50 harmonised to master contains changes from 50-harmonised-file-conforms-to-new-standard-format and some new updates for running the new format. it includes:
1. change bp to srt, to prevent the .0 in bp.
2. not output headers for counting the direction of variants
3. allow -coordinate is empty and set default as 1-based
4. Do not delete the original file