### PR TITLE
feat: Migrate from LSF to SLURM

### DIFF
--- a/example_wrapper.sh
+++ b/example_wrapper.sh
@@ -13,4 +13,4 @@ mkdir -p $folder
 
 cd $folder
 nextflow $nextflow -c $config --inputPath $folder --to_harm_folder $to_harm -resume 
-#further function: --execute local(or LSF)
+#further function: --execute local (or SLURM)

--- a/nextflow.config
+++ b/nextflow.config
@@ -87,7 +87,7 @@ profiles {
         process.executor = 'local'
     }
     cluster {
-        process.executor = 'lsf'
+        process.executor = 'slurm'
         process.queue = 'short'
         process.memory = '28GB'
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -88,8 +88,8 @@ profiles {
     }
     cluster {
         process.executor = 'slurm'
-        process.queue = 'short'
         process.memory = '28GB'
+        process.time = '2d'
     }
     conda {
         params.enable_conda    = true


### PR DESCRIPTION
This commit changes the job scheduler in the project's configuration and wrapper script from LSF to SLURM.

Also, see https://github.com/EBISPOT/goci/issues/1179