### PR TITLE
update to pre_gwas_ssf harmonisation pipeline

### DIFF
--- a/config/container.config
+++ b/config/container.config
@@ -14,6 +14,6 @@ process {
     ext.conda = "$projectDir/environments/conda_environment.yml"
     ext.docker = 'ebispot/gwas-sumstats-harmoniser'
     ext.singularity = 'docker://ebispot/gwas-sumstats-harmoniser'
-    ext.docker_version = ':latest'
-    ext.singularity_version = ':latest'
+    ext.docker_version = ':v1.0.8'
+    ext.singularity_version = ':v1.0.8'
     }

--- a/config/test.config
+++ b/config/test.config
@@ -1,10 +1,10 @@
 params {
     to_build='38' 
     chrom='22'
-    ref="$HOME/.nextflow/assets/EBISPOT/gwas-sumstats-harmoniser/test_data"
+    ref="$NXF_ASSETS/EBISPOT/gwas-sumstats-harmoniser/test_data"
     threshold='0.99'
     harm = true
-    file="$HOME/.nextflow/assets/EBISPOT/gwas-sumstats-harmoniser/test_data/GCST1.tsv"
+    file="$NXF_ASSETS/EBISPOT/gwas-sumstats-harmoniser/test_data/GCST1.tsv"
     }
 
 process{

--- a/modules/local/concatenate_chr_splits.nf
+++ b/modules/local/concatenate_chr_splits.nf
@@ -1,4 +1,5 @@
 process concatenate_chr_splits {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/modules/local/generate_strand_counts.nf
+++ b/modules/local/generate_strand_counts.nf
@@ -1,4 +1,6 @@
 process generate_strand_counts {
+    tag "$GCST"
+    
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&
@@ -7,7 +9,7 @@ process generate_strand_counts {
         "${task.ext.docker}${task.ext.docker_version}" }"
         
     input:
-    tuple val(GCST), val(chrom), path(merged), path(vcf), val(status)
+    tuple val(GCST), val(chrom), path(merged), path(yaml), path(ref), val(status)
 
     output:
     tuple val(GCST), val(status), path("full_${chrom}.sc"), emit: all_sc
@@ -18,10 +20,14 @@ process generate_strand_counts {
     shell:
     """
     header_args=\$(utils.py -f $merged -strand_count_args);
+    coordinate_system=\$(grep coordinate_system $yaml | awk -F ":" '{print \$2}' | tr -d "[:blank:]" )
+    if test -z "\$coordinate_system"; then coordinate="1-base"; else coordinate=\$coordinate_system; fi
+
     main_pysam.py \
     --sumstats $merged \
     --vcf ${params.ref}/homo_sapiens-${chrom}.vcf.gz \
     \$header_args \
     --strand_counts full_${chrom}.sc
+    -coordinate \$coordinate
     """
 }

--- a/modules/local/generate_strand_counts.nf
+++ b/modules/local/generate_strand_counts.nf
@@ -28,6 +28,6 @@ process generate_strand_counts {
     --vcf ${params.ref}/homo_sapiens-${chrom}.vcf.gz \
     \$header_args \
     --strand_counts full_${chrom}.sc
-    -coordinate \$coordinate
+    --coordinate \$coordinate
     """
 }

--- a/modules/local/harmonization.nf
+++ b/modules/local/harmonization.nf
@@ -10,7 +10,7 @@ process harmonization {
     tag "$GCST"
 
     input:
-    tuple val(GCST), val(palin_mode), val(status), val(chrom), path(merged), path(ref), path(yaml)
+    tuple val(GCST), val(palin_mode), val(status), val(chrom), path(merged), path(yaml), path(ref)
 
 
     output:

--- a/modules/local/harmonization.nf
+++ b/modules/local/harmonization.nf
@@ -23,7 +23,7 @@ process harmonization {
     """
 
     coordinate_system=\$(grep coordinate_system $yaml | awk -F ":" '{print \$2}' | tr -d "[:blank:]" )
-    if test -z "\$coordinate_system"; then coordinate="1-base"; else coordinate=\$coordinate_system; fi
+    if test -z "\$coordinate_system"; then coordinate="1_base"; else coordinate=\$coordinate_system; fi
 
     header_args=\$(utils.py -f $merged -harm_args);
     

--- a/modules/local/harmonization.nf
+++ b/modules/local/harmonization.nf
@@ -1,5 +1,5 @@
 process harmonization {
-
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/modules/local/harmonization_log.nf
+++ b/modules/local/harmonization_log.nf
@@ -1,4 +1,5 @@
 process harmonization_log {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/modules/local/map_to_build.nf
+++ b/modules/local/map_to_build.nf
@@ -1,4 +1,5 @@
 process map_to_build {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&
@@ -11,7 +12,7 @@ process map_to_build {
     val chr
 
     output:
-    tuple val(GCST), path ('*.merged'), path('unmapped'), emit:mapped
+    tuple val(GCST), path ('*.merged'), path('unmapped'), path(yaml), emit:mapped
 
     shell:
     """

--- a/modules/local/map_to_build.nf
+++ b/modules/local/map_to_build.nf
@@ -17,7 +17,7 @@ process map_to_build {
     shell:
     """
     coordinate_system=\$(grep coordinate_system $yaml | awk -F ":" '{print \$2}' | tr -d "[:blank:]" )
-    if test -z "\$coordinate_system"; then coordinate="1-base"; else coordinate=\$coordinate_system; fi
+    if test -z "\$coordinate_system"; then coordinate="1_base"; else coordinate=\$coordinate_system; fi
 
     from_build=\$((grep genome_assembly $yaml | grep -Eo '[0-9][0-9]') || (echo \$(basename $tsv) | grep -Eo '[bB][a-zA-Z]*[0-9][0-9]' | grep -Eo '[0-9][0-9]'))
     [[ -z "\$from_build" ]] && { echo "Parameter from_build is empty" ; exit 1; }

--- a/modules/local/qc.nf
+++ b/modules/local/qc.nf
@@ -1,4 +1,5 @@
 process qc {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/modules/local/summarise_strand_counts.nf
+++ b/modules/local/summarise_strand_counts.nf
@@ -1,4 +1,5 @@
 process summarise_strand_counts {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/modules/local/ten_percent_counts.nf
+++ b/modules/local/ten_percent_counts.nf
@@ -35,6 +35,6 @@ process ten_percent_counts {
     --vcf ${params.ref}/homo_sapiens-${chrom}.vcf.gz \
     \$header_args \
     --strand_counts ten_percent_${chrom}.sc \
-    -coordinate \$coordinate
+    --coordinate \$coordinate
     """
 }

--- a/modules/local/ten_percent_counts.nf
+++ b/modules/local/ten_percent_counts.nf
@@ -27,7 +27,7 @@ process ten_percent_counts {
     header_args=\$(utils.py -f $merged -strand_count_args);
 
     coordinate_system=\$(grep coordinate_system $yaml | awk -F ":" '{print \$2}' | tr -d "[:blank:]" )
-    if test -z "\$coordinate_system"; then coordinate="1-base"; else coordinate=\$coordinate_system; fi
+    if test -z "\$coordinate_system"; then coordinate="1_base"; else coordinate=\$coordinate_system; fi
 
 
     main_pysam.py \

--- a/modules/local/ten_percent_counts_sum.nf
+++ b/modules/local/ten_percent_counts_sum.nf
@@ -1,4 +1,5 @@
 process ten_percent_counts_sum {
+    tag "$GCST"
     conda (params.enable_conda ? "${task.ext.conda}" : null)
 
     container "${ workflow.containerEngine == 'singularity' &&

--- a/subworkflows/local/main_harm.nf
+++ b/subworkflows/local/main_harm.nf
@@ -8,9 +8,9 @@ workflow main_harm {
     //files: [GCST,path yaml, path tsv]
 
     main:
-    yaml_path_ch=files.map{it[0,1]}
-    harm_input=hm_input.combine(yaml_path_ch,by:0)
-    harmonization(harm_input)
+    //yaml_path_ch=files.map{it[0,1]}
+    //harm_input=hm_input.combine(yaml_path_ch,by:0)
+    harmonization(hm_input)
     //hm_by_chrom: [GCST009150, forward, path of hm, path of log]
     //hm_input.map{it[6]}.dump(tag:'bar')
     id_palin_ch = harmonization.out.hm_by_chrom.map{it[0,1]}.unique()

--- a/subworkflows/local/major_direction.nf
+++ b/subworkflows/local/major_direction.nf
@@ -16,7 +16,7 @@ workflow major_direction{
     //example: output is [GCST1,[path of 1.merged, path of 2.merged .....]]
     map_to_build.out.mapped
                     .transpose()
-                    .map{tuple(get_chr(it[1]),it[0],it[1])}
+                    .map{tuple(get_chr(it[1]),it[0],it[1],it[3])}
                     .set{map_chr_ch}
     // capture unmapped sites for reporting
     unmapped = map_to_build.out.mapped.map{it[2]}

--- a/subworkflows/local/major_direction.nf
+++ b/subworkflows/local/major_direction.nf
@@ -21,7 +21,7 @@ workflow major_direction{
     // capture unmapped sites for reporting
     unmapped = map_to_build.out.mapped.map{it[2]}
     
-    //example: out of map_to_build [GCST010681,[1,2,...]] tranpose into [[GCST010681,path 1.merged],[GCST010681,path 2.merged]] and then into [chr1,GCST010681,path 1.merged][chr2,GCST010681,path 2.merged].....
+    //example: out of map_to_build [GCST010681,[1,2,...]] tranpose into [[GCST010681,path 1.merged,path of yaml],[GCST010681,path 2.merged,path of yaml]] and then into [chr1,GCST010681,path 1.merged,path of yaml][chr2,GCST010681,path 2.merged,path of yaml].....
     
     Channel.fromPath("${params.ref}/homo_sapiens-chr*.vcf.gz") 
            .map { prepare_reference (it) }
@@ -34,8 +34,8 @@ workflow major_direction{
     count_ch=map_chr_ch.combine(ref_chr_ch,by:0)
     /* example
     [chr1, path of homo_sapiens-chr1.vcf.gz] (ref_chr_ch) + 
-    [chr1, GCST1, path of 1.merged] (map_chr_ch)
-    -> [chr1, GCST1, path of 1.merged,path of homo_sapiens-chr1.vcf.gz] (count_ch) 
+    [chr1, GCST1, path of 1.merged, path of yaml] (map_chr_ch)
+    -> [chr1, GCST1, path of 1.merged, path of yaml,path of homo_sapiens-chr1.vcf.gz] (count_ch) 
     */
     
     ten_percent_counts(count_ch)
@@ -76,12 +76,12 @@ workflow major_direction{
     // [GCST, ten_percent, forward,contiune] (contiune_branch)
     all_files=summarise_strand_counts.out.all_sum.mix(branch.contiune)
     //hm_input: [GCST,path ten_percent.tsv,forward,countiune],[GCST,path Full.tsv,reverse,countiune]
-    rearrnaged_count_ch=count_ch.map{tuple(it[1],it[0],it[2],it[3])}
+    rearrnaged_count_ch=count_ch.map{tuple(it[1],it[0],it[2],it[3],it[4])}
     // example: [chr1, GCST1, path of 1.merged,path of homo_sapiens-chr1.vcf.gz] (count_ch) 
     // example into: [GCST1,chr1,path of merged, path of vcf]
     all_input=all_files.combine(rearrnaged_count_ch,by:0)
     //example: [GCST,path ten_percent.tsv,forward,countiune,chr,path of merged, path of vcf]
-    hm_input=all_input.map{it[0,2..6]}
+    hm_input=all_input.map{it[0,2..7]}
     direction_sum=all_input.map{it[0..1]}.unique()
 
     emit:

--- a/test_data/GCST0.tsv-meta.yaml
+++ b/test_data/GCST0.tsv-meta.yaml
@@ -17,7 +17,7 @@ data_file_md5sum: 32ce41c3dca4cd9f463a0ce7351966fd
 is_harmonised: false
 is_sorted: false
 fileDescription: GWAS summary statistics; author uploaded.
-date_last_modified: 2023-02-09
+date_metadata_last_modified: 2023-02-09
 genome_assembly: GRCh37
 coordinate_system: 0-based
 effectStatistic: beta

--- a/test_data/GCST1.tsv-meta.yaml
+++ b/test_data/GCST1.tsv-meta.yaml
@@ -17,7 +17,7 @@ data_file_md5sum: 32ce41c3dca4cd9f463a0ce7351966fd
 is_harmonised: false
 is_sorted: false
 fileDescription: GWAS summary statistics; author uploaded.
-date_last_modified: 2023-02-09
+date_metadata_last_modified: 2023-02-09
 genome_assembly: GRCh37
 coordinate_system: 1-based
 effectStatistic: beta


### PR DESCRIPTION
1. Tag each process so that we can know the GCST id within one process even though their output name is the same.
2. Update the test.config file to recognise the test data are in the $NXF_ASSETS folder instead of the $HOME/.nextflow/asset folder
3. Update the test yaml data since we updated the field `date_last_modified` as `date_metadata_last_modified`
4. Allow the yaml file to be accessible by the count the strand direction step.
5. Pre-gwas-ssf cannot use the latest branch. Update the version with the upcoming release version v1.0.8