### PR TITLE
Fix typo in palindromes

### DIFF
--- a/bin/main_pysam.py
+++ b/bin/main_pysam.py
@@ -113,7 +113,7 @@ def main():
         # Harmonise palindromic alleles
         elif is_palindromic(ss_rec.other_al, ss_rec.effect_al):
 
-            strand_counter['Palindormic variant'] += 1
+            strand_counter['Palindromic variant'] += 1
             if args.hm_sumstats:
                 ss_rec = harmonise_palindromic(ss_rec, vcf_rec)
 

--- a/bin/sum_strand_counts_10percent_nf.py
+++ b/bin/sum_strand_counts_10percent_nf.py
@@ -13,7 +13,7 @@ from utils import *
 def aggregate_counts(in_dir,out,threshold):
 
     variant_type_dict = {
-        "Palindormic variant": 0,
+        "Palindromic variant": 0,
         "Forward strand variant": 0,
         "Reverse strand variant": 0,
         "No VCF record found": 0,

--- a/bin/sum_strand_counts_nf.py
+++ b/bin/sum_strand_counts_nf.py
@@ -13,7 +13,7 @@ from utils import *
 def aggregate_counts(in_dir, out, threshold):
 
     variant_type_dict = {
-        "Palindormic variant": 0,
+        "Palindromic variant": 0,
         "Forward strand variant": 0,
         "Reverse strand variant": 0,
         "No VCF record found": 0,


### PR DESCRIPTION
Just noticed this small typo in the human-readable outputs, thought it might be useful to fix.