### PR TITLE
Partial fix for hard-coded GCST #101

### DIFF
--- a/modules/local/harmonization.nf
+++ b/modules/local/harmonization.nf
@@ -43,6 +43,6 @@ process harmonization {
     pos=\$(awk -v RS='\t' '/base_pair_location/{print NR; exit}' ${chrom}.merged_unsorted.hm)
 
     head -n1 ${chrom}.merged_unsorted.hm > ${chrom}.merged.hm;
-    tail -n+2 ${chrom}.merged_unsorted.hm | sort -n -k\$chr -k\$pos >> ${chrom}.merged.hm
+    tail -n+2 ${chrom}.merged_unsorted.hm | sort -n -k\$chr -k\$pos -T\$PWD >> ${chrom}.merged.hm
     """
 }

--- a/workflows/gwascatalogharm.nf
+++ b/workflows/gwascatalogharm.nf
@@ -86,7 +86,7 @@ workflow GWASCATALOGHARM {
 
 def input_files(Path input)
 {
-    return [(input.getName()=~ /GCST\d+/).findAll()[0],input+"-meta.yaml",input]
+    return [input.getName().split("\\.")[0],input+"-meta.yaml",input]
 }
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There are currently multiple points in the pipeline where errors are raised due to the expectation that the study name starts with "GCST". This fixes one of them so that the study name in the metadata yaml file doesn't need to be GCST*.

The harmonization pipeline still exits with an error at the end when it is collecting metrics. I believe this is because GCST is also hard-coded in gwas_sumstats_tools.schema.metadata.SumStatsMetadata from gwas-sumstats-tools (https://pypi.org/project/gwas-sumstats-tools/). 

Nextflow log:
```
executor >  slurm (56)
[e2/d0e39e] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 2 of 2, failed: 1...
[9f/2106e9] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 25 of 25 ✔
[1a/0c48b1] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 1 of 1 ✔
[-        ] process > NFCORE_GWASCATALOGHARM:GWAS... -
[-        ] process > NFCORE_GWASCATALOGHARM:GWAS... -
[05/b5b195] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 25 of 25, failed:...
[35/3f542c] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 1 of 1 ✔
[57/ee4335] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 1 of 1 ✔
[80/7c50b8] process > NFCORE_GWASCATALOGHARM:GWAS... [100%] 1 of 1, failed: 1 ✔
[80/7c50b8] NOTE: Process `NFCORE_GWASCATALOGHARM:GWASCATALOGHARM:quality_control:harmonization_log (CAD)` terminated with an error exit status (1) -- Error is ignored
Completed at: 26-Sep-2024 22:06:02
Duration    : 1h 26m 20s
CPU hours   : 10.1 (0.8% failed)
Succeeded   : 51
Ignored     : 4
Failed      : 5
```

.command.log from failed job:
```/hpfs/userws/chiouj02/projects/gwas_harmonizer/harmonisation_resources/homo_sapiens-chr13.vcf.gz,CAD.uh.tsv.gz,ten_percent_total_strand_count.tsv,report.txt,harmonised.tsv,unmapped,,,CAD.running.log
Traceback (most recent call last):
  File "/bin/gwas_metadata.py", line 71, in <module>
    main()
  File "/bin/gwas_metadata.py", line 60, in main
    m.from_file()
  File "/bin/gwas_metadata.py", line 21, in from_file
    self.update_metadata(self._meta_dict)
  File "/bin/gwas_metadata.py", line 34, in update_metadata
    self.metadata = self.metadata.parse_obj(self._meta_dict)
  File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 2 validation errors for SumStatsMetadata
gwas_id
  string does not match regex "^GCST\d+$" (type=value_error.str.regex; pattern=^GCST\d+$)
samples
  value is not a valid list (type=type_error.list)```