### PR TITLE
Updated requests, numpy, PyYAML versions for gwas-sumstats-tools v1.0.22

### DIFF
--- a/environments/conda_environment.yml
+++ b/environments/conda_environment.yml
@@ -22,7 +22,7 @@ dependencies:
         - ipython-genutils==0.2.0
         - jsonschema==3.2.0
         - nbformat==5.0.6
-        - numpy
+        - numpy==1.25.0
         - pandas
         - psutil==5.7.0
         - pyarrow
@@ -31,9 +31,9 @@ dependencies:
         - pysam==0.18.0
         - python-dateutil==2.8.2
         - pytz==2020.1
-        - PyYAML==5.3.1
+        - PyYAML>=6.0,<7.0
         - ratelimiter==1.2.0.post0
-        - requests==2.23.0
+        - requests>=2.28.2,<3.0.0
         - six==1.15.0
         - smmap==3.0.4
         - toposort==1.5


### PR DESCRIPTION
In order to build the `conda` environment, I had to adjust the version of `requests` and `PyYAML` to make them compatible with the newest version of `gwas-sumstats-tools`.  [There was a similar PR](https://github.com/EBISPOT/gwas-sumstats-harmoniser/pull/107) for an earlier version of this package. 

Building the environment also required that I specify version `1.25.0` of `numpy` to resolve an issue with `gwas-sumstats-tools` [described here](https://github.com/EBISPOT/gwas-sumstats-tools/issues/45).